### PR TITLE
Add maximum spanning tree functions

### DIFF
--- a/graph/graph-fns-spantree.rkt
+++ b/graph/graph-fns-spantree.rkt
@@ -10,20 +10,27 @@
          (only-in "../queue/priority.rkt" mk-empty-priority)
          (only-in "../queue/fifo.rkt" mk-empty-fifo))
 
-(provide mst-kruskal mst-prim)
+(provide min-st-kruskal max-st-kruskal
+         min-st-prim max-st-prim)
 
 (define-syntax-rule (first x) (unsafe-car x))
 (define-syntax-rule (second x) (unsafe-car (unsafe-cdr x)))
 
-;; minimum spanning tree fns
+;; spanning tree fns
 
 ;; kruskal --------------------------------------------------------------------
 ;; uses data/union-find
 
-(define (mst-kruskal G)
+(define (min-st-kruskal G)
+  (kruskal G <))
+
+(define (max-st-kruskal G)
+  (kruskal G >))
+
+(define (kruskal G order)
   (define wgt (if (weighted-graph? G) (λ (e) (apply edge-weight G e)) (λ _ 1)))
   (define sorted-edges 
-    (if (weighted-graph? G) (sort (get-edges G) < #:key wgt) (get-edges G)))
+    (if (weighted-graph? G) (sort (get-edges G) order #:key wgt) (get-edges G)))
   
   ;; map vertex to it's representative set
   ;;  (different vertices may map to the same rep set)
@@ -39,35 +46,37 @@
 ;; uses priority queue based on in data/heap
 
 ;; The "visited" vertices (ie vertices that have been enqueued then dequeued)
-;; represent the current mst.
+;; represent the current spanning tree.
 ;; The vertices in the priority queue (ie heap) represent the candidate "next"
-;; vertices to add to the mst.
+;; vertices to add to the spanning tree.
 ;; It might seem like the visited? check is not needed, since we're adding the 
-;; lowest weight edge on each iteration and then only enqueueing if there's
-;; improvement, but the check is needed to ensure all the edges form a mst.
-;; If we omit the check, I think we're only guaranteed a cover set.
+;; lowest (or highest, depending on the 'order' parameters) weight edge on each
+;; iteration and then only enqueueing if there's improvement, but the check is
+;; needed to ensure all the edges form a tree. If we omit the check, I think
+;; we're only guaranteed a cover set.
 ;;
-;; If a vertex v is already in the mst, then:
+;; If a vertex v is already in the tree, then:
 ;; - ((π v) v) is the edge connected v to the rest of the tree
 ;; - (cur-min-wgt v) is the weight of that edge
 ;; If a vertex v is a candidate vertex (ie, in the heap), then:
-;; - (π v) is the vertex that would connect v to the mst
-;; - where (π v) is chosen among all possible edges from v to the mst bc it has
-;;   the lowest weight, where (cur-min-wgt v) is that weight
+;; - (π v) is the vertex that would connect v to the tree
+;; - where (π v) is chosen among all possible edges from v to the tree bc it
+;;   has the lowest/highest weight, where (cur-min-wgt v) is that weight
 ;;
 ;; On each iteration:
-;; - candidate vertex with lowest weight connecting edge is added to the mst
+;; - candidate vertex with lowest/highest weight connecting edge is added to
+;;   the tree
 ;; - neighbors of that vertex are added as candidates
 ;;
 ;; Notes:
-;; - a vertex can be "enqueued" agani even if it's already in the heap, 
-;;   if another edge of that vertex is later discovered to be cheaper than the
-;;   currently known cheapest edge
+;; - a vertex can be "enqueued" again even if it's already in the heap, 
+;;   if another edge of that vertex is later discovered to be more optimal
+;;   than the currently known optimal edge
 ;; - thus re-enqueueing a vertex that's already in the heap effectively
 ;;   "re-heapifies" the heap with the new cost information
-(define (mst-prim G root-v)
+(define (min-st-prim G root-v)
   (define wgt (if (weighted-graph? G) (λ (u v) (edge-weight G u v)) (λ _ 1)))
-  ; (cur-min-wgt v) is current known min wgt edge connecting v to the mst
+  ; (cur-min-wgt v) is current known min wgt edge connecting v to the tree
   (define-vertex-property G cur-min-wgt #:init +inf.0) 
   (define-vertex-property G π #:init #f)
 
@@ -80,13 +89,39 @@
     #:init: (cur-min-wgt-set! root-v 0)
     ;; default bfs skips visit if v is discovered (ie it's been seen before) 
     ;; (ie enqueued or visited) (ie not "white")
-    ;; but we skip only if v has been visited (ie in the mst) (ie it's "black")
+    ;; but we skip only if v has been visited (ie in the tree) (ie it's "black")
     ;; but we re-enqueue if we discover lower cost information for the vertex
     #:enqueue?: (and (not ($visited? $v))
                      (< (wgt $from $v)
                         (cur-min-wgt $v)))
     #:on-enqueue: (cur-min-wgt-set! $v (wgt $from $v)) 
                   (π-set! $v $from)
-    ;; return list of edges in the mst
+    ;; return list of edges in the tree
+    #:return: (for/list ([v (in-vertices G)] #:unless (vertex=? G v root-v))
+               (list (π v) v))))
+
+(define (max-st-prim G root-v)
+  (define wgt (if (weighted-graph? G) (λ (u v) (edge-weight G u v)) (λ _ 1)))
+  ; (cur-max-wgt v) is current known max wgt edge connecting v to the tree
+  (define-vertex-property G cur-max-wgt #:init -inf.0) 
+  (define-vertex-property G π #:init #f)
+
+  (define hp 
+    (if (weighted-graph? G)
+        (mk-empty-priority (λ (u v) (> (cur-max-wgt u) (cur-max-wgt v))))
+        (mk-empty-fifo)))
+  
+  (do-bfs G root-v #:init-queue: hp
+    #:init: (cur-max-wgt-set! root-v 0)
+    ;; default bfs skips visit if v is discovered (ie it's been seen before) 
+    ;; (ie enqueued or visited) (ie not "white")
+    ;; but we skip only if v has been visited (ie in the tree) (ie it's "black")
+    ;; but we re-enqueue if we discover lower cost information for the vertex
+    #:enqueue?: (and (not ($visited? $v))
+                     (> (wgt $from $v)
+                        (cur-max-wgt $v)))
+    #:on-enqueue: (cur-max-wgt-set! $v (wgt $from $v)) 
+                  (π-set! $v $from)
+    ;; return list of edges in the tree
     #:return: (for/list ([v (in-vertices G)] #:unless (vertex=? G v root-v))
                (list (π v) v))))

--- a/graph/graph.scrbl
+++ b/graph/graph.scrbl
@@ -483,7 +483,7 @@ algorithm makes use of the special identifiers @racket[$v] and @racket[$from].
     #:return: (values (d->hash) (π->hash))))
     )
 
-@racket[bfs], @racket[fewest-vertices-path], @racket[cc/bfs], @racket[mst-prim], 
+@racket[bfs], @racket[fewest-vertices-path], @racket[cc/bfs], @racket[min-st-prim], @racket[max-st-prim]
 and @racket[dijkstra] all use the @racket[do-bfs] form.}
                
 @defproc[(fewest-vertices-path [G graph?] [source any/c] [target any/c]) (or/c list? #f)]{
@@ -713,9 +713,13 @@ Indicates whether a graph is directed and acyclic.}
 @; min span trees -------------------------------------------------------------
 @section{Minimum Spanning Tree}
 
-@defproc[(mst-kruskal [g graph?]) (listof (list/c any/c any/c))]{Computes the minimum spanning tree using Kruskal's algorithm and the @racket[data/union-find] data structure. Returns a list of edges.}
+@defproc[(min-st-kruskal [g graph?]) (listof (list/c any/c any/c))]{Computes the minimum spanning tree using Kruskal's algorithm and the @racket[data/union-find] data structure. Returns a list of edges.}
 
-@defproc[(mst-prim [g graph?] [source any/c]) (listof (list/c any/c any/c))]{Computes the minimum spanning tree of a graph using Prim's algorithm, which is based on breadth-first search. Returns a list of edges.}
+@defproc[(max-st-kruskal [g graph?]) (listof (list/c any/c any/c))]{Computes the maximum spanning tree using Kruskal's algorithm and the @racket[data/union-find] data structure. Returns a list of edges.}
+
+@defproc[(min-st-prim [g graph?] [source any/c]) (listof (list/c any/c any/c))]{Computes the minimum spanning tree of a graph using Prim's algorithm, which is based on breadth-first search. Returns a list of edges.}
+
+@defproc[(max-st-prim [g graph?] [source any/c]) (listof (list/c any/c any/c))]{Computes the maximum spanning tree of a graph using Prim's algorithm, which is based on breadth-first search. Returns a list of edges.}
 
 @; single source shortest paths -----------------------------------------------
 @section{Single-source Shortest Paths}

--- a/graph/main.rkt
+++ b/graph/main.rkt
@@ -5,7 +5,7 @@
          "graph-weighted.rkt"
          "graph-matrix.rkt"
          "graph-fns-basic.rkt"
-         "graph-fns-minspantree.rkt"
+         "graph-fns-spantree.rkt"
          "graph-fns-singlesource-shortestpaths.rkt"
          "graph-fns-allpairs-shortestpaths.rkt"
          "graph-fns-coloring.rkt"
@@ -25,7 +25,7 @@
                      [mk-matrix-graph matrix-graph])
          weighted-graph? unweighted-graph? matrix-graph?
          (all-from-out "graph-fns-basic.rkt"
-                       "graph-fns-minspantree.rkt"
+                       "graph-fns-spantree.rkt"
                        "graph-fns-singlesource-shortestpaths.rkt"
                        "graph-fns-coloring.rkt"
                        "graph-fns-maxflow.rkt"

--- a/graph/tests/graph-fns-spantree-tests.rkt
+++ b/graph/tests/graph-fns-spantree-tests.rkt
@@ -1,6 +1,6 @@
 #lang racket
 (require "../graph-weighted.rkt"
-         "../graph-fns-minspantree.rkt"
+         "../graph-fns-spantree.rkt"
          "test-utils.rkt")
 
 (require rackunit)
@@ -12,31 +12,37 @@
      (10 e f) (4 c f) (2 c i) (7 h i) (6 g i) (1 h g) (2 g f))))
 
 ;; both (a h) or (b c) are ok
-(check-expected-msts (mst-kruskal g23.1)
-                     '((a b) (a h) (c i) (c f) (f g) (g h) (c d) (d e))
-                     '((a b) (b c) (c i) (c f) (f g) (g h) (c d) (d e)))
+(check-expected-span-trees (min-st-kruskal g23.1)
+                           '((a b) (a h) (c i) (c f) (f g) (g h) (c d) (d e))
+                           '((a b) (b c) (c i) (c f) (f g) (g h) (c d) (d e)))
 
-(check-expected-msts (mst-prim g23.1 'a)
-                     '((a b) (b c) (c i) (c f) (f g) (g h) (c d) (d e))
-                     '((a b) (a h) (c i) (c f) (f g) (g h) (c d) (d e)))
+(check-expected-span-trees (max-st-kruskal g23.1)
+                           '((d f) (h b) (a h) (b c) (h i) (g i) (c d) (f e)))
+
+(check-expected-span-trees (min-st-prim g23.1 'a)
+                           '((a b) (b c) (c i) (c f) (f g) (g h) (c d) (d e))
+                           '((a b) (a h) (c i) (c f) (f g) (g h) (c d) (d e)))
+
+(check-expected-span-trees (max-st-prim g23.1 'a)
+                           '((a h) (h b) (h i) (b c) (g i) (c d) (d f) (f e)))
 
 ;; since g23.1 is an undirected graph, the previous test is correct but this test
 ;; additionally checks that edges are going in the right direction
-(check-true (or (equal? (apply set (mst-prim g23.1 'a))
+(check-true (or (equal? (apply set (min-st-prim g23.1 'a))
                         (apply set '((a b) (b c) (c i) (c f) (f g) (g h) (c d) (d e))))
-                (equal? (apply set (mst-prim g23.1 'a))
+                (equal? (apply set (min-st-prim g23.1 'a))
                         (apply set '((a b) (a h) (c i) (c f) (f g) (g h) (c d) (d e))))))
 
 ;; from wikipedia (2014-07-01)
 (define g/wik (mk-undirected-graph '((a b) (a d) (b d) (c d)) '(2 1 2 3)))
-(check-expected-msts (mst-prim g/wik 'a) '((a d) (b d) (c d))
-                                         '((a d) (b a) (d c)))
+(check-expected-span-trees (min-st-prim g/wik 'a) '((a d) (b d) (c d))
+                                                  '((a d) (b a) (d c)))
 
 ;; http://scanftree.com/Data_Structure/prim's-algorithm
 (define g/cpp (mk-undirected-graph
                '((0 1) (0 2) (0 3) (1 2) (1 4) (2 3) (2 4) (2 5) (3 5) (4 5))
                '(3 1 6 5 3 5 6 4 2 6)))
-(check-expected-msts (mst-prim g/cpp 0) '((0 1) (0 2) (1 4) (2 5) (5 3)))
+(check-expected-span-trees (min-st-prim g/cpp 0) '((0 1) (0 2) (1 4) (2 5) (5 3)))
 
 ;; boost example
 ;; http://www.boost.org/doc/libs/1_38_0/boost/graph/prim_minimum_spanning_tree.hpp
@@ -45,4 +51,4 @@
                  '((0 2) (1 3) (1 4) (2 1) (2 3) (3 4) (4 0))
                  '(1 1 2 7 3 1 1)))
 
-(check-expected-msts (mst-prim g/boost 0) '((1 3) (2 0) (3 4) (4 0)))
+(check-expected-span-trees (min-st-prim g/boost 0) '((1 3) (2 0) (3 4) (4 0)))

--- a/graph/tests/run-all-tests.rkt
+++ b/graph/tests/run-all-tests.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 
 (require "graph-fns-basic-tests.rkt"
-         "graph-fns-minspantree-tests.rkt"
+         "graph-fns-spantree-tests.rkt"
          "graph-fns-singlesource-shortestpaths-tests.rkt"
          "graph-fns-allpairs-shortestpaths-tests.rkt"
          "graph-fns-coloring-tests.rkt"

--- a/graph/tests/test-utils.rkt
+++ b/graph/tests/test-utils.rkt
@@ -22,7 +22,7 @@
   (check-equal? (apply set (sequence->list s1)) 
                 (apply set (sequence->list s2))))
 
-(define-syntax-rule (check-expected-msts to-check expected ...)
+(define-syntax-rule (check-expected-span-trees to-check expected ...)
   (let ([res to-check])
     (check-true (or (equal? (lists->sets res) (lists->sets expected)) ...))))
                     

--- a/graph/tests/timing-tests.rkt
+++ b/graph/tests/timing-tests.rkt
@@ -3,7 +3,7 @@
 (require "../graph-weighted.rkt"
          "../graph-unweighted.rkt"
          "../graph-fns-singlesource-shortestpaths.rkt"
-         "../graph-fns-minspantree.rkt"
+         "../graph-fns-spantree.rkt"
          "../graph-fns-basic.rkt"
          "../gen-graph.rkt"
          "test-utils.rkt")
@@ -41,16 +41,16 @@
 
 (define KRUSKAL-TIME-LIMIT 80) ; ms
 
-;; mst-kruskal
-(let-values ([(res cpu real gc) (time-apply mst-kruskal (list g/cours))])
+;; min-st-kruskal
+(let-values ([(res cpu real gc) (time-apply min-st-kruskal (list g/cours))])
   (when (> real KRUSKAL-TIME-LIMIT) (displayln real))
   (check-true (< real KRUSKAL-TIME-LIMIT)))
 
 ;; most are ~3ms; v=71: ~7ms
 (define PRIM-TIME-LIMIT 20) ; ms
 
-;; mst-prim
+;; min-st-prim
 (for ([v (in-vertices g/cours)] #:when (odd? v))
-  (define-values (res cpu real gc) (time-apply mst-prim (list g/cours v)))
+  (define-values (res cpu real gc) (time-apply min-st-prim (list g/cours v)))
 ;  (when (> real PRIM-TIME-LIMIT) (displayln real) (displayln v))
   (check-true (< real PRIM-TIME-LIMIT)))


### PR DESCRIPTION
### Motivation

I have been using this excellent library for examining and constructing divide trees from digital elevation models. I recently discovered that the algorithm for constructing a suitable divide tree from a graph could be vastly simplified by, in part, determining the maximum spanning tree. It seems like a handy tool to have in this library.

### Caveats

This would be a change to the interface of the library; I renamed the minimum spanning tree (ST) functions to more clearly differentiate them from the new maximum ST functions. It's not huge, but I know that changing the names of any library symbols is not undertaken lightly.

Suggested changes and improvements welcome.