### PR TITLE
Explicitly allow non-numerical edges

### DIFF
--- a/graph-doc/graph/scribblings/graph.scrbl
+++ b/graph-doc/graph/scribblings/graph.scrbl
@@ -48,7 +48,7 @@ A @tech{graph} has the following methods:
   @item{@defproc[(in-neighbors [g graph?] [v any/c]) sequence?]{Returns a sequence of vertex @racket[v]'s neighbors in the graph.}}
   @item{@defproc[(get-edges [g graph?]) list?]{Returns a list of edges in the graph.}}
   @item{@defproc[(in-edges [g graph?]) sequence?]{Returns a sequence of edges in the graph.}}
-  @item{@defproc[(edge-weight [g graph?] [u any/c] [v any/c] [#:default default any/c +inf.0]) number?]{Returns the weight of the edge in the graph, if it has one. For non-existent edges, returns the specified default.
+  @item{@defproc[(edge-weight [g graph?] [u any/c] [v any/c] [#:default default any/c +inf.0]) any/c?]{Returns the weight of the edge in the graph, if it has one. For non-existent edges, returns the specified default.
   @history[#:changed "0.5.1" "added default argument"]}}
   @item{@defproc[(transpose [g graph?]) graph?]{Returns a new graph where the edges of the original graph are reversed.}}
   @item{@defproc[(graph-copy [g graph?]) graph?]{Returns a copy of the given graph.}}
@@ -110,9 +110,9 @@ which create either a weighted or unweighted graph.
 
 @defproc[(weighted-graph? [g any/c]) boolean?]{Indicates whether a graph is a weighted graph.}
 
-@defproc[(weighted-graph/undirected [edges (listof (list/c number? any/c any/c))])
+@defproc[(weighted-graph/undirected [edges (listof (list/c any/c any/c any/c))])
          (and/c graph? weighted-graph?)]{
-  Creates a weighted graph that implements @racket[gen:graph] from a list of weighted, undirected edges. Each edge is represented by a list of one number and two vertices, where the number is the weight. Vertices can be any Racket values comparable with @racket[equal?].
+  Creates a weighted graph that implements @racket[gen:graph] from a list of weighted, undirected edges. Each edge is represented by a list of one weight (label) and two vertices. Vertices can be any Racket values comparable with @racket[equal?]. Weights can be any Racket values comparable with @racket[equal?]. Note that some algorithms will fail on non-numerical egde weights.
 @examples[#:eval the-eval
   (define g (weighted-graph/undirected '((10 a b) (20 b c))))
   (graph? g)
@@ -124,9 +124,9 @@ which create either a weighted or unweighted graph.
   ]
 }
                                           
-@defproc[(weighted-graph/directed [edges (listof (list/c number? any/c any/c))])
+@defproc[(weighted-graph/directed [edges (listof (list/c any/c any/c any/c))])
          (and/c graph? weighted-graph?)]{
-Creates a weighted graph that implements @racket[gen:graph] from a list of weighted, directed edges. Each edge is represented by a list of one number and two vertices, where the number is the weight, and the first vertex in the list is the source and the second vertex is the destination. Vertices can be any Racket values comparable with @racket[equal?]. Non-existent edges return an infinite weight, even for non-existent vertices.
+Creates a weighted graph that implements @racket[gen:graph] from a list of weighted, directed edges. Each edge is represented by a list of one weight (label) and two vertices, and the first vertex in the list is the source and the second vertex is the destination. Vertices can be any Racket values comparable with @racket[equal?]. Non-existent edges return an infinite weight, even for non-existent vertices. In general, weights can be any Racket values comparable with @racket[equal?]. Note that some algorithms will fail on non-numerical egde weights.
 @examples[#:eval the-eval
   (define g (weighted-graph/directed '((10 a b) (20 b c))))
   (graph? g)
@@ -138,10 +138,10 @@ Creates a weighted graph that implements @racket[gen:graph] from a list of weigh
   (edge-weight g 'b 'd)
   ]}
 
-@defproc[(undirected-graph [edges (listof (list/c number? any/c any/c))]
-                           [wgts (listof number?) #f])
+@defproc[(undirected-graph [edges (listof (list/c any/c any/c any/c))]
+                           [wgts (listof any/c) #f])
          (and/c graph? (or/c unweighted-graph? weighted-graph?))]{
-  Creates either a weighted or unweighted graph that implements @racket[gen:graph] from a list of undirected edges and possibly a list of weights. Each edge is represented by a list of two vertices. Vertices can be any Racket values comparable with @racket[equal?]. If a list of weights is provided, then the result is a weighted graph. Otherwise, the result is an unweighted graph. The number of weights must equal the number of edges.
+  Creates either a weighted or unweighted graph that implements @racket[gen:graph] from a list of undirected edges and possibly a list of weights. Each edge is represented by a list of two vertices. Vertices can be any Racket values comparable with @racket[equal?]. If a list of weights is provided, then the result is a weighted graph. Otherwise, the result is an unweighted graph. The number of weights must equal the number of edges. Weights can be any Racket values comparable with @racket[equal?]. Note that some algorithms will fail on non-numerical egde weights.
 @examples[#:eval the-eval
   (define g (undirected-graph '((a b) (b c)) '(10 20)))
   (graph? g)
@@ -156,10 +156,10 @@ Creates a weighted graph that implements @racket[gen:graph] from a list of weigh
   ]
 }
                                           
-@defproc[(directed-graph [edges (listof (list/c number? any/c any/c))]
-                         [wgts (listof number?) #f])
+@defproc[(directed-graph [edges (listof (list/c any/c any/c any/c))]
+                         [wgts (listof any/c) #f])
          (and/c graph? (or/c unweighted-graph? weighted-graph?))]{
-Creates either a weighted or unweighted graph that implements @racket[gen:graph] from a list of directed edges and possibly a list of weights. Each edge is represented by a list of two vertices where the first vertex in the list is the source and the second vertex is the destination. Vertices can be any Racket values comparable with @racket[equal?]. If a list of weights is provided, then the result is a weighted graph. Otherwise, the result is an unweighted graph. The number of weights must equal the number of edges. Non-existent edges return an infinite weight, even for non-existent vertices.
+Creates either a weighted or unweighted graph that implements @racket[gen:graph] from a list of directed edges and possibly a list of weights. Each edge is represented by a list of two vertices where the first vertex in the list is the source and the second vertex is the destination. Vertices can be any Racket values comparable with @racket[equal?]. If a list of weights is provided, then the result is a weighted graph. Otherwise, the result is an unweighted graph. The number of weights must equal the number of edges. Non-existent edges return an infinite weight, even for non-existent vertices. Weights can be any Racket values comparable with @racket[equal?]. Note that some algorithms will fail on non-numerical egde weights.
 @examples[#:eval the-eval
   (define g (directed-graph '((a b) (b c)) '(10 20)))
   (graph? g)

--- a/graph-lib/graph/graph-fns-graphviz.rkt
+++ b/graph-lib/graph/graph-fns-graphviz.rkt
@@ -56,8 +56,8 @@
                 ([e (in-edges g)]
                  #:when (and (not (set-member? added e))
                              (has-edge? g (second e) (first e))
-                             (= (edge-weight g (first e) (second e))
-                                (edge-weight g (second e) (first e)))))
+                             (equal? (edge-weight g (first e) (second e))
+                                     (edge-weight g (second e) (first e)))))
         (printf "\t\t~a -> ~a~a;\n" 
           (node-id-table-ref! (first e))
           (node-id-table-ref! (second e))

--- a/graph-test/tests/graph/graphviz.rkt
+++ b/graph-test/tests/graph/graphviz.rkt
@@ -57,20 +57,20 @@
 ;; 	subgraph D {
 ;; 	}
 ;; }
-(check-true (string-contains? bf-viz-color "[color=\"0.0 1.0 1.0\"]"))
-(check-true (string-contains? bf-viz-color "[color=\"0.333 1.0 1.0\"]"))
-(check-true (string-contains? bf-viz-color "[color=\"0.666 1.0 1.0\"]"))
-(check-true (string-contains? bf-viz-color "[color=\"0.0 1.0 1.0\"]"))
-(check-true (string-contains? bf-viz-color "[color=\"0.333 1.0 1.0\"]"))
+(check-true (string-contains? bf-viz-color "color=\"0.0 1.0 1.0\""))
+(check-true (string-contains? bf-viz-color "color=\"0.333 1.0 1.0\""))
+(check-true (string-contains? bf-viz-color "color=\"0.666 1.0 1.0\""))
+(check-true (string-contains? bf-viz-color "color=\"0.0 1.0 1.0\""))
+(check-true (string-contains? bf-viz-color "color=\"0.333 1.0 1.0\""))
 (check-butterfly-viz-output bf-viz-color)
 
 (define bf-viz-color-brelaz 
   (graphviz butterfly #:colors (coloring/brelaz butterfly)))
-(check-true (string-contains? bf-viz-color-brelaz "[color=\"0.333 1.0 1.0\"]"))
-(check-true (string-contains? bf-viz-color-brelaz "[color=\"0.666 1.0 1.0\"]"))
-(check-true (string-contains? bf-viz-color-brelaz "[color=\"0.0 1.0 1.0\"]"))
-(check-true (string-contains? bf-viz-color-brelaz "[color=\"0.333 1.0 1.0\"]"))
-(check-true (string-contains? bf-viz-color-brelaz "[color=\"0.666 1.0 1.0\"]"))
+(check-true (string-contains? bf-viz-color-brelaz "color=\"0.333 1.0 1.0\""))
+(check-true (string-contains? bf-viz-color-brelaz "color=\"0.666 1.0 1.0\""))
+(check-true (string-contains? bf-viz-color-brelaz "color=\"0.0 1.0 1.0\""))
+(check-true (string-contains? bf-viz-color-brelaz "color=\"0.333 1.0 1.0\""))
+(check-true (string-contains? bf-viz-color-brelaz "color=\"0.666 1.0 1.0\""))
 (check-butterfly-viz-output bf-viz-color-brelaz)
 
 (define fruit-labeled

--- a/graph-test/tests/graph/graphviz.rkt
+++ b/graph-test/tests/graph/graphviz.rkt
@@ -72,3 +72,70 @@
 (check-true (string-contains? bf-viz-color-brelaz "[color=\"0.333 1.0 1.0\"]"))
 (check-true (string-contains? bf-viz-color-brelaz "[color=\"0.666 1.0 1.0\"]"))
 (check-butterfly-viz-output bf-viz-color-brelaz)
+
+(define fruit-labeled
+  (weighted-graph/directed '(["tastier" "tomato" "potato"]
+                             [10 "apple" "tomato"]
+                             [11 "apple" "potato"]
+                             [better "banana" "apple" ])))
+(check-equal? (edge-weight fruit-labeled "tomato" "potato") "tastier")
+(check-equal? (edge-weight fruit-labeled "apple" "tomato") 10)
+(check-equal? (edge-weight fruit-labeled "apple" "potato") 11)
+(check-equal? (edge-weight fruit-labeled "banana" "apple") 'better)
+
+(define fruit-labeled-viz (graphviz fruit-labeled))
+;; eg,
+;; digraph G {
+;; 	node0 [label="banana"];
+;; 	node1 [label="tomato"];
+;; 	node2 [label="apple"];
+;; 	node3 [label="potato"];
+;; 	subgraph U {
+;; 		edge [dir=none];
+;; 	}
+;; 	subgraph D {
+;; 		node0 -> node2 [label="better"];
+;; 		node1 -> node3 [label="tastier"];
+;; 		node2 -> node1 [label="10"];
+;; 		node2 -> node3 [label="11"];
+;; 	}
+;; }
+(check-true (string-contains? fruit-labeled-viz "\\[label=\"better\"\\]"))
+(check-true (string-contains? fruit-labeled-viz "\\[label=\"tastier\"\\]"))
+(check-true (string-contains? fruit-labeled-viz "\\[label=\"10\"\\]"))
+(check-true (string-contains? fruit-labeled-viz "\\[label=\"11\"\\]"))
+
+(define cities-labeled
+  (weighted-graph/undirected '([far "Berlin" "New York"]
+                               ["near" "New York" "Boston"]
+                               [1000 "Berlin" "Boston"]
+                               ["very far" "New York" "Sydney"])))
+(define (check-undirected-edge-label-equal? gr u v label)
+  (check-equal? (edge-weight gr u v) label)
+  (check-equal? (edge-weight gr v u) label))
+(check-undirected-edge-label-equal? cities-labeled "Berlin" "New York" 'far)
+(check-undirected-edge-label-equal? cities-labeled "New York" "Boston" "near")
+(check-undirected-edge-label-equal? cities-labeled "Berlin" "Boston" 1000)
+(check-undirected-edge-label-equal? cities-labeled "New York" "Sydney" "very far")
+
+(define cities-labeled-viz (graphviz cities-labeled))
+;; eg,
+;; digraph G {
+;; 	node0 [label="Sydney"];
+;; 	node1 [label="Berlin"];
+;; 	node2 [label="New York"];
+;; 	node3 [label="Boston"];
+;; 	subgraph U {
+;; 		edge [dir=none];
+;; 		node0 -> node2 [label="very far"];
+;; 		node1 -> node3 [label="1000"];
+;; 		node1 -> node2 [label="far"];
+;; 		node2 -> node3 [label="near"];
+;; 	}
+;; 	subgraph D {
+;; 	}
+;; }
+(check-true (string-contains? cities-labeled-viz "\\[label=\"very far\"\\]"))
+(check-true (string-contains? cities-labeled-viz "\\[label=\"1000\"\\]"))
+(check-true (string-contains? cities-labeled-viz "\\[label=\"far\"\\]"))
+(check-true (string-contains? cities-labeled-viz "\\[label=\"near\"\\]"))


### PR DESCRIPTION
The graph library does not really enforce edge weights to be numerical, but the documentation currently seems to imply that edge weights are protected by the contract `number?`. Apparently, this is not the case, as non-numerical edges can be created without any particular issues.

This pull request does the following modifications:

1. Modify the documentation to explicitly state that edge weights can be any values comparable with `equal?`.  EDIT: Explicitly say that some algorithms will not work for non-numerical weights.  (I think BFS and DFS should be fine, probably also SCCs, spanning trees, etc.)
2. Modify the `graphviz` function to compare edge weights with `equal?` instead of `=` (@stchang 's idea).
3. Add some new tests for `graphviz` to ensure that non-numerical edge labels are rendered correctly.
4. Fix a small mistake in some other tests of `graphviz` (essentially, escape or don't use square brackets, because this captures too many patterns).