### PR TITLE
Add matrix->matrix-graph.

### DIFF
--- a/graph-doc/graph/scribblings/graph.scrbl
+++ b/graph-doc/graph/scribblings/graph.scrbl
@@ -15,7 +15,7 @@ Generic graph library for Racket.
 Requires Racket 6.0 or later.
 
 @(define the-eval (make-base-eval))
-@(the-eval '(require graph))
+@(the-eval '(require graph math/matrix))
 
 @author[@author+email["Stephen Chang" "stchang@racket-lang.org"]]
 
@@ -203,7 +203,28 @@ NOTE: @racket[matrix-graph] is implemented with @racket[matrix], so the same typ
   (floyd-warshall g)
   ]
 }
-                                          
+
+@defproc[(matrix->matrix-graph [mtx array?]) matrix-graph?]{
+  Creates a matrix graph from a matrix. Vertices are the (0-based)
+row/column numbers and the weights are the number at each row-column. Use
+@racket[#f] to indicate no edge.
+
+@examples[#:eval the-eval
+  (define g (matrix->matrix-graph
+             (matrix [[0 3 8 #f -4]
+                      [#f 0 #f 1 7]
+                      [#f 4 0 #f #f]
+                      [2 #f -5 0 #f]
+                      [#f #f #f 6 0]])))
+  (graph? g)
+  (matrix-graph? g)
+  (has-edge? g 0 1)
+  (has-edge? g 1 0)
+  (edge-weight g 0 1)
+  (edge-weight g 1 0)
+  (floyd-warshall g)
+  ]
+}
 
 @; graph properties -----------------------------------------------------------
 @section{Graph properties}

--- a/graph-lib/graph/graph-matrix.rkt
+++ b/graph-lib/graph/graph-matrix.rkt
@@ -9,7 +9,7 @@
 ;; The entry in the matrix at row i, col j represents the weight of edge i-j.
 ;; A non-existent edge is denoted with #f.
 
-(provide mk-matrix-graph matrix-graph?)
+(provide mk-matrix-graph matrix->matrix-graph matrix-graph?)
 
 (define-syntax-rule (get-matrix g) (unsafe-struct*-ref g 0))
 
@@ -85,3 +85,7 @@
   (let ([m (matrix rows)])
     (unless (square-matrix? m) (error 'mk-matrix-graph "graph must be a square matrix"))
     (matrix-graph (array->mutable-array m))))
+
+(define (matrix->matrix-graph mtx)
+  (unless (square-matrix? mtx) (error 'matrix->matrix-graph "graph must be a square matrix"))
+  (matrix-graph (array->mutable-array mtx)))

--- a/graph-lib/graph/main.rkt
+++ b/graph-lib/graph/main.rkt
@@ -23,7 +23,7 @@
                      [mk-directed-graph directed-graph]
                      [mk-undirected-graph undirected-graph]
                      [mk-matrix-graph matrix-graph])
-         weighted-graph? unweighted-graph? matrix-graph?
+         weighted-graph? unweighted-graph? matrix-graph? matrix->matrix-graph
          (all-from-out "graph-fns-basic.rkt"
                        "graph-fns-spantree.rkt"
                        "graph-fns-singlesource-shortestpaths.rkt"

--- a/graph-test/tests/graph/graph-fns-allpairs-shortestpaths-tests.rkt
+++ b/graph-test/tests/graph/graph-fns-allpairs-shortestpaths-tests.rkt
@@ -3,6 +3,7 @@
          graph/graph-weighted
          graph/graph-matrix
          graph/graph-fns-allpairs-shortestpaths
+         math/matrix
          "test-utils.rkt"
          rackunit)
 
@@ -18,11 +19,12 @@
      (6 5 4))))
 
 (define matrix25.1
-  (mk-matrix-graph [[0 3 8 #f -4]
-                    [#f 0 #f 1 7]
-                    [#f 4 0 #f #f]
-                    [2 #f -5 0 #f]
-                    [#f #f #f 6 0]]))
+  (matrix->matrix-graph (matrix [[0 3 8 #f -4]
+                                 [#f 0 #f 1 7]
+                                 [#f 4 0 #f #f]
+                                 [2 #f -5 0 #f]
+                                 [#f #f #f 6 0]])))
+
 
 (define weights25.1slow (all-pairs-shortest-paths/slow g25.1))
 (define weights25.1faster (all-pairs-shortest-paths/faster g25.1))


### PR DESCRIPTION
Add the function `matrix->matrix-graph` which does essentially the same thing as the `mk-matrix-graph` syntax rule, but will be easier to add to the Typed Racket interface, see Issue #58 .

Weirdly enough, I had to do quite a bit of head scratching for this PR, and I am particularly unsure about the following things:

* the name of the new function;
* the fact that it shares a lot of code with the `mk-matrix-graph` syntax rule, but factoring that code out would probably require a submodule, required once `for-syntax` and once at the same level, which looks like an overkill for two lines, but I don't know.

What do you think?