### PR TITLE
Add ability to customize Graphviz attributes

### DIFF
--- a/graph-doc/graph/scribblings/graph.scrbl
+++ b/graph-doc/graph/scribblings/graph.scrbl
@@ -893,7 +893,8 @@ with its value.
 The other two associate an attribute name with
 either an @tech{edge property} or @tech{vertex property}
 that yields the attribute value for that element of the graph.
-These attributes take precedence over any default ones
+These attributes take precedence over the attributes
+set by @racket[#:colors] and any default ones
 (like edge labels derived from the weights).
 }
 

--- a/graph-doc/graph/scribblings/graph.scrbl
+++ b/graph-doc/graph/scribblings/graph.scrbl
@@ -864,13 +864,15 @@ Note: this is not the Hopcroft-Karp (ie fastest) bipartite matching algorithm.}
 @defproc[(graphviz
           [g graph?]
           [#:output output (or/c output-port? #f) #f]
-          [#:colors colors (or/c (hash/c any/c natural-number/c) #f) #f])
+          [#:colors colors (or/c (hash/c any/c natural-number/c) #f) #f]
+          [#:edge-attributes edge-attrs (listof (list/c symbol? procedure?)) null]
+          [#:vertex-attributes vertex-attrs (listof (list/c symbol? procedure?)) null])
          string?]{
 Returns the dotfile representation of the given graph (as a string).
 
 The optional color argument maps vertices to colors, where the color
 corresponds to the "H" component of an HSV color representation. The given
-colors are normalized to be between 0 and 1.0 before generating the graphviz
+colors are normalized to be between 0 and 1.0 before generating the Graphviz
 output, with the maximum specified color value corresponding to 1.0 (the S and
 V components are currently unspecifiable and are always 1.0).
 
@@ -879,7 +881,15 @@ Typically, the color argument is the output of a function from
 
 The optional output argument redirects the output from a
 string to the given output port. A string is returned when
-the argument is @racket[#f].}
+the argument is @racket[#f].
+
+The @racket[#:edge-attributes] and @racket[#:vertex-attributes]
+options attach Graphviz attributes to edges and vertices, respectively.
+They take a list containing associations between an attribute name (as a symbol)
+and either an @tech{edge property} or @tech{vertex property}
+that yields the value for that attribute.
+These attributes take precedence over the default attributes.
+}
 
 @; other
 @section{Other}

--- a/graph-doc/graph/scribblings/graph.scrbl
+++ b/graph-doc/graph/scribblings/graph.scrbl
@@ -865,6 +865,7 @@ Note: this is not the Hopcroft-Karp (ie fastest) bipartite matching algorithm.}
           [g graph?]
           [#:output output (or/c output-port? #f) #f]
           [#:colors colors (or/c (hash/c any/c natural-number/c) #f) #f]
+          [#:graph-attributes graph-attrs (listof (list/c symbol? any/c)) null]
           [#:edge-attributes edge-attrs (listof (list/c symbol? procedure?)) null]
           [#:vertex-attributes vertex-attrs (listof (list/c symbol? procedure?)) null])
          string?]{
@@ -883,12 +884,17 @@ The optional output argument redirects the output from a
 string to the given output port. A string is returned when
 the argument is @racket[#f].
 
-The @racket[#:edge-attributes] and @racket[#:vertex-attributes]
-options attach Graphviz attributes to edges and vertices, respectively.
-They take a list containing associations between an attribute name (as a symbol)
-and either an @tech{edge property} or @tech{vertex property}
-that yields the value for that attribute.
-These attributes take precedence over the default attributes.
+The @racket[#:graph-attributes], @racket[#:edge-attributes],
+and @racket[#:vertex-attributes] options attach Graphviz attributes to the
+graph, edges, and vertices, respectively.
+For @racket[#:graph-attributes],
+the argument is a list that associates an attribute name (as a symbol)
+with its value.
+The other two associate an attribute name with
+either an @tech{edge property} or @tech{vertex property}
+that yields the attribute value for that element of the graph.
+These attributes take precedence over any default ones
+(like edge labels derived from the weights).
 }
 
 @; other

--- a/graph-lib/graph/graph-fns-graphviz.rkt
+++ b/graph-lib/graph/graph-fns-graphviz.rkt
@@ -1,27 +1,67 @@
 #lang racket/base
 
-(require racket/port racket/format racket/set racket/unsafe/ops racket/pretty)
-(require "gen-graph.rkt" "graph-weighted.rkt")
+(require racket/format
+         (only-in racket/list
+                  remove-duplicates)
+         racket/port
+         racket/pretty
+         racket/set
+         racket/string
+         racket/unsafe/ops
+         "gen-graph.rkt"
+         "graph-weighted.rkt")
 
 (provide graphviz)
 
 (define-syntax-rule (first x) (unsafe-car x))
 (define-syntax-rule (second x) (unsafe-car (unsafe-cdr x)))
 
-(define (sanatize-name name)
+(define (sanitize-name name)
   (cond
-    [(string? name) (with-output-to-string
-                        (λ () (write name)))]
-    [(symbol? name) (sanatize-name (symbol->string name))]
-    [(number? name) (sanatize-name (number->string name))]
-    [else (sanatize-name
-           (with-output-to-string
-               (λ () (pretty-print name))))]))
+    [(string? name) name]
+    [(symbol? name) (symbol->string name)]
+    [(number? name) (number->string name)]
+    [else (pretty-format name)]))
+
+(define (color-attr colors color-count v)
+  (if (and color-count (hash-ref colors v #f))
+      (let* ([percent (/ (hash-ref colors v #f) color-count)]
+             [str (~a #:max-width 5 (exact->inexact percent))]
+             [triple (format "~a 1.0 1.0" str)])
+        `([color ,triple]))
+      null))
+
+(define (weight-attr weighted? g e)
+  (if weighted?
+      (let ([weight (edge-weight g (first e) (second e))])
+        `([label ,(sanitize-name weight)]))
+      null))
+
+(define (vertex-attrs-get-val attrs v)
+  (for/list ([attr (in-list attrs)])
+    (define get (cadr attr))
+    (list (car attr) (get v))))
+
+(define (edge-attrs-get-val attrs e)
+  (for/list ([attr (in-list attrs)])
+    (define get (cadr attr))
+    (list (car attr) (get (first e) (second e)))))
+
+(define (attrs->string attrs)
+  (define attrs* (remove-duplicates attrs #:key car))
+  (define attr-strs
+    (for/list ([attr (in-list attrs*)])
+      (format "~a=~s" (car attr) (cadr attr))))
+  (if (null? attrs)
+      ""
+      (format "[~a]" (string-join attr-strs ","))))
 
 ;; Return a graphviz definition for a graph
 ;; Pass a hash of vertex -> exact-nonnegative-integer? as coloring to color the nodes
 (define (graphviz g
                   #:colors [colors #f]
+                  #:edge-attributes [edge-attrs null]
+                  #:vertex-attributes [vertex-attrs null]
                   #:output [port #f])
    (define (generate-graph)
      (parameterize ([current-output-port (or port (current-output-port))])
@@ -37,16 +77,13 @@
        ; Add vertices, color them using evenly spaced HSV colors if given colors
        (define color-count (and colors (add1 (apply max (hash-values colors)))))
     (for ([v (in-vertices g)])
-      (cond
-        [(and color-count (hash-ref colors v #f))
-         (printf "\t~a [label=~a,color=\"~a 1.0 1.0\"];\n" (node-id-table-ref! v)
-                 (sanatize-name v)
-                 (~a #:max-width 5
-                     (exact->inexact (/ (hash-ref colors v #f) color-count))))]
-        [else
-         (printf "\t~a [label=~a];\n"
-                 (node-id-table-ref! v)
-                 (sanatize-name v))]))
+        (define attrs
+          (append (vertex-attrs-get-val vertex-attrs v)
+                  `([label ,(sanitize-name v)])
+                  (color-attr colors color-count v)))
+        (printf "\t~a ~a;\n"
+                (node-id-table-ref! v)
+                (attrs->string attrs)))
         
     ; Write undirected edges as one subgraph
     (printf "\tsubgraph U {\n")
@@ -58,20 +95,26 @@
                              (has-edge? g (second e) (first e))
                              (equal? (edge-weight g (first e) (second e))
                                      (edge-weight g (second e) (first e)))))
-        (printf "\t\t~a -> ~a~a;\n" 
-          (node-id-table-ref! (first e))
-          (node-id-table-ref! (second e))
-          (if weighted? (format " [label=\"~a\"]" (edge-weight g (first e) (second e))) ""))
+          (define attrs
+            (append (edge-attrs-get-val edge-attrs e)
+                    (weight-attr weighted? g e)))
+          (printf "\t\t~a -> ~a ~a;\n"
+                  (node-id-table-ref! (first e))
+                  (node-id-table-ref! (second e))
+                  (attrs->string attrs))
         (set-add (set-add added e) (list (second e) (first e)))))
     (printf "\t}\n")
         
     ; Write directed edges as another subgraph
     (printf "\tsubgraph D {\n")
     (for ([e (in-edges g)] #:unless (set-member? undirected-edges e))
-      (printf "\t\t~a -> ~a~a;\n" 
-        (node-id-table-ref! (first e))
-        (node-id-table-ref! (second e))
-        (if weighted? (format " [label=\"~a\"]" (edge-weight g (first e) (second e))) "")))
+        (define attrs
+          (append (edge-attrs-get-val edge-attrs e)
+                  (weight-attr weighted? g e)))
+        (printf "\t\t~a -> ~a ~a;\n"
+                (node-id-table-ref! (first e))
+                (node-id-table-ref! (second e))
+                (attrs->string attrs)))
     (printf "\t}\n")
     (printf "}\n")))
   (if port

--- a/graph-lib/graph/graph-fns-graphviz.rkt
+++ b/graph-lib/graph/graph-fns-graphviz.rkt
@@ -63,20 +63,20 @@
                   #:edge-attributes [edge-attrs null]
                   #:vertex-attributes [vertex-attrs null]
                   #:output [port #f])
-   (define (generate-graph)
-     (parameterize ([current-output-port (or port (current-output-port))])
-       (define weighted? (weighted-graph? g))
-       (define node-count 0)
-       (define node-id-table (make-hash))
-       (define (node-id-table-ref! node)
-         (hash-ref! node-id-table node
-                    (λ ()
-                      (begin0 (format "node~a" node-count)
-                              (set! node-count (add1 node-count))))))
-       (printf "digraph G {\n")
-       ; Add vertices, color them using evenly spaced HSV colors if given colors
-       (define color-count (and colors (add1 (apply max (hash-values colors)))))
-    (for ([v (in-vertices g)])
+  (define (generate-graph)
+    (parameterize ([current-output-port (or port (current-output-port))])
+      (define weighted? (weighted-graph? g))
+      (define node-count 0)
+      (define node-id-table (make-hash))
+      (define (node-id-table-ref! node)
+        (hash-ref! node-id-table node
+                   (λ ()
+                     (begin0 (format "node~a" node-count)
+                       (set! node-count (add1 node-count))))))
+      (printf "digraph G {\n")
+      ; Add vertices, color them using evenly spaced HSV colors if given colors
+      (define color-count (and colors (add1 (apply max (hash-values colors)))))
+      (for ([v (in-vertices g)])
         (define attrs
           (append (vertex-attrs-get-val vertex-attrs v)
                   `([label ,(sanitize-name v)])
@@ -84,17 +84,17 @@
         (printf "\t~a ~a;\n"
                 (node-id-table-ref! v)
                 (attrs->string attrs)))
-        
-    ; Write undirected edges as one subgraph
-    (printf "\tsubgraph U {\n")
-    (printf "\t\tedge [dir=none];\n")
-    (define undirected-edges
-      (for/fold ([added (set)]) 
-                ([e (in-edges g)]
-                 #:when (and (not (set-member? added e))
-                             (has-edge? g (second e) (first e))
-                             (equal? (edge-weight g (first e) (second e))
-                                     (edge-weight g (second e) (first e)))))
+
+      ; Write undirected edges as one subgraph
+      (printf "\tsubgraph U {\n")
+      (printf "\t\tedge [dir=none];\n")
+      (define undirected-edges
+        (for/fold ([added (set)])
+                  ([e (in-edges g)]
+                   #:when (and (not (set-member? added e))
+                               (has-edge? g (second e) (first e))
+                               (equal? (edge-weight g (first e) (second e))
+                                       (edge-weight g (second e) (first e)))))
           (define attrs
             (append (edge-attrs-get-val edge-attrs e)
                     (weight-attr weighted? g e)))
@@ -102,12 +102,12 @@
                   (node-id-table-ref! (first e))
                   (node-id-table-ref! (second e))
                   (attrs->string attrs))
-        (set-add (set-add added e) (list (second e) (first e)))))
-    (printf "\t}\n")
-        
-    ; Write directed edges as another subgraph
-    (printf "\tsubgraph D {\n")
-    (for ([e (in-edges g)] #:unless (set-member? undirected-edges e))
+          (set-add (set-add added e) (list (second e) (first e)))))
+      (printf "\t}\n")
+
+      ; Write directed edges as another subgraph
+      (printf "\tsubgraph D {\n")
+      (for ([e (in-edges g)] #:unless (set-member? undirected-edges e))
         (define attrs
           (append (edge-attrs-get-val edge-attrs e)
                   (weight-attr weighted? g e)))
@@ -115,8 +115,8 @@
                 (node-id-table-ref! (first e))
                 (node-id-table-ref! (second e))
                 (attrs->string attrs)))
-    (printf "\t}\n")
-    (printf "}\n")))
+      (printf "\t}\n")
+      (printf "}\n")))
   (if port
       (generate-graph)
       (with-output-to-string generate-graph)))

--- a/graph-test/tests/graph/graphviz.rkt
+++ b/graph-test/tests/graph/graphviz.rkt
@@ -152,11 +152,13 @@
 
 (define custom-attrs-viz
   (graphviz custom-attrs
+            #:graph-attributes `([rankdir "LR"])
             #:vertex-attributes `([label ,label] [shape ,shape])
             #:edge-attributes `([arrowhead ,arrowhead])))
 
 ;; eg,
 ;; digraph G {
+;; 	rankdir="LR";
 ;; 	node0 [label="THERE",shape="oval"];
 ;; 	node1 [label="HERE",shape="house"];
 ;; 	subgraph U {
@@ -167,6 +169,7 @@
 ;; 	}
 ;; }
 
+(check-true (string-contains? custom-attrs-viz "rankdir=\"LR\""))
 (check-true (string-contains? custom-attrs-viz "\\[label=\"THERE\",shape=\"oval\"]"))
 (check-true (string-contains? custom-attrs-viz "\\[label=\"HERE\",shape=\"house\"]"))
 (check-true (string-contains? custom-attrs-viz "\\[arrowhead=\"obox\"]"))

--- a/graph-test/tests/graph/graphviz.rkt
+++ b/graph-test/tests/graph/graphviz.rkt
@@ -139,3 +139,34 @@
 (check-true (string-contains? cities-labeled-viz "\\[label=\"1000\"\\]"))
 (check-true (string-contains? cities-labeled-viz "\\[label=\"far\"\\]"))
 (check-true (string-contains? cities-labeled-viz "\\[label=\"near\"\\]"))
+
+(define custom-attrs
+  (unweighted-graph/directed '(["here" "there"])))
+
+(define-vertex-property custom-attrs label #:init (string-upcase $v))
+(define-vertex-property custom-attrs shape #:init "oval")
+(shape-set! "here" "house")
+
+(define-edge-property custom-attrs arrowhead)
+(arrowhead-set! "here" "there" "obox")
+
+(define custom-attrs-viz
+  (graphviz custom-attrs
+            #:vertex-attributes `([label ,label] [shape ,shape])
+            #:edge-attributes `([arrowhead ,arrowhead])))
+
+;; eg,
+;; digraph G {
+;; 	node0 [label="THERE",shape="oval"];
+;; 	node1 [label="HERE",shape="house"];
+;; 	subgraph U {
+;; 		edge [dir=none];
+;; 	}
+;; 	subgraph D {
+;; 		node1 -> node0 [arrowhead="obox"];
+;; 	}
+;; }
+
+(check-true (string-contains? custom-attrs-viz "\\[label=\"THERE\",shape=\"oval\"]"))
+(check-true (string-contains? custom-attrs-viz "\\[label=\"HERE\",shape=\"house\"]"))
+(check-true (string-contains? custom-attrs-viz "\\[arrowhead=\"obox\"]"))


### PR DESCRIPTION
Two optional arguments to `graphviz` support customizing the attributes of vertices and edges via vertex and edge properties. This makes it possible to customize the Graphviz output much more easily.